### PR TITLE
Add support for converting description param to .describe() call

### DIFF
--- a/src/convert-description-param.ts
+++ b/src/convert-description-param.ts
@@ -1,0 +1,66 @@
+import { ObjectLiteralExpression, SyntaxKind } from "ts-morph";
+import { getDirectDescendantsOfKind, type ZodNode } from "./zod-node.ts";
+
+export function convertDescriptionParamToDescribeCall(node: ZodNode) {
+  getDirectDescendantsOfKind(node, SyntaxKind.Identifier)
+    .filter(
+      (id) =>
+        id.getText() === "description" &&
+        (id.getParentIfKind(SyntaxKind.PropertyAssignment) !== undefined ||
+          id.getParentIfKind(SyntaxKind.ShorthandPropertyAssignment) !==
+            undefined),
+    )
+    .map((id) =>
+      id.getParent()?.getParentIfKind(SyntaxKind.ObjectLiteralExpression),
+    )
+    .filter(
+      (objectLiteral): objectLiteral is ObjectLiteralExpression =>
+        objectLiteral !== undefined,
+    )
+    .forEach((objectLiteral) => {
+      const callExpression = objectLiteral.getParentIfKind(
+        SyntaxKind.CallExpression,
+      );
+      if (!callExpression) {
+        return;
+      }
+
+      const descriptionProp = objectLiteral.getProperty("description");
+      if (!descriptionProp) {
+        return;
+      }
+
+      let descriptionValue: string;
+      if (descriptionProp.isKind(SyntaxKind.ShorthandPropertyAssignment)) {
+        descriptionValue = descriptionProp.getName();
+      } else if (descriptionProp.isKind(SyntaxKind.PropertyAssignment)) {
+        const initializer = descriptionProp.getInitializer();
+        if (!initializer) {
+          return;
+        }
+
+        // Skip if value is a Zod expression (e.g., z.object({description: z.string()}))
+        if (
+          initializer.isKind(SyntaxKind.CallExpression) ||
+          initializer.isKind(SyntaxKind.PropertyAccessExpression)
+        ) {
+          return;
+        }
+
+        descriptionValue = initializer.getText();
+      } else {
+        return;
+      }
+
+      descriptionProp.remove();
+
+      // If only `{}` is left, remove it
+      if (objectLiteral.getProperties().length === 0) {
+        callExpression.removeArgument(objectLiteral);
+      }
+
+      callExpression.replaceWithText(
+        `${callExpression.getText()}.describe(${descriptionValue})`,
+      );
+    });
+}

--- a/src/migrate.ts
+++ b/src/migrate.ts
@@ -9,6 +9,7 @@ import {
   getZodName,
 } from "./collect-imports.ts";
 import { convertAstroDeprecatedZodImports } from "./convert-astro-imports.ts";
+import { convertDescriptionParamToDescribeCall } from "./convert-description-param.ts";
 import {
   convertZArrayPatternsToTopLevelApi,
   convertZCoercePatternsToTopLevelApi,
@@ -90,6 +91,7 @@ export function migrateZodV3ToV4(
     convertErrorMapToErrorFunction(parentStatement);
     convertMessageKeyToError(parentStatement);
     convertDeprecatedErrorKeysToErrorFunction(parentStatement);
+    convertDescriptionParamToDescribeCall(parentStatement);
     convertZNumberPatternsToZInt(parentStatement, zodName);
     convertZStringPatternsToTopLevelApi(parentStatement, zodName);
     convertZCoercePatternsToTopLevelApi(parentStatement, zodName);

--- a/test/__scenarios__/description-param.input.ts
+++ b/test/__scenarios__/description-param.input.ts
@@ -1,0 +1,58 @@
+import { z } from "zod";
+
+// Basic types with description
+z.boolean({ description: "A boolean value" });
+z.string({ description: "A string value" });
+z.number({ description: "A number value" });
+z.date({ description: "A date value" });
+
+// Description with chained methods
+z.string({ description: "An email" }).email();
+z.number({ description: "A positive number" }).min(0);
+
+// Description combined with error keys
+z.string({
+  description: "User name",
+  required_error: "Name is required",
+  invalid_type_error: "Must be a string",
+});
+
+// Description combined with coerce
+z.number({ description: "Coerced number", coerce: true });
+
+// Description with message
+z.string({
+  description: "Important field",
+  message: "Invalid value",
+});
+
+// Shorthand property assignment
+const description = "My schema";
+z.boolean({ description });
+
+// Variable reference
+const myDesc = "Dynamic description";
+z.string({ description: myDesc });
+
+// Template literal
+z.number({ description: `Count of items` });
+
+// z.object with description in second params argument
+z.object({ name: z.string() }, { description: "A user object" });
+
+// z.object shape field named "description" -- should NOT be transformed
+z.object({ description: z.string() });
+
+// z.object with both: shape field AND second-arg description
+z.object(
+  { description: z.string(), name: z.string() },
+  { description: "Schema with description field" },
+);
+
+// Description with errorMap that only returns defaults (gets removed)
+z.string({
+  description: "With error map",
+  errorMap: (issue, ctx) => {
+    return { message: ctx.defaultError };
+  },
+});

--- a/test/__scenarios__/description-param.output.ts
+++ b/test/__scenarios__/description-param.output.ts
@@ -1,0 +1,50 @@
+import { z } from "zod/v4";
+
+// Basic types with description
+z.boolean().describe("A boolean value");
+z.string().describe("A string value");
+z.number().describe("A number value");
+z.date().describe("A date value");
+
+// Description with chained methods
+z.email().describe("An email");
+z.number().describe("A positive number").min(0);
+
+// Description combined with error keys
+z.string({
+  error: (issue) =>
+    issue.input === undefined ? "Name is required" : "Must be a string",
+}).describe("User name");
+
+// Description combined with coerce
+z.coerce.number().describe("Coerced number");
+
+// Description with message
+z.string({
+  error: "Invalid value",
+}).describe("Important field");
+
+// Shorthand property assignment
+const description = "My schema";
+z.boolean().describe(description);
+
+// Variable reference
+const myDesc = "Dynamic description";
+z.string().describe(myDesc);
+
+// Template literal
+z.number().describe(`Count of items`);
+
+// z.object with description in second params argument
+z.object({ name: z.string() }).describe("A user object");
+
+// z.object shape field named "description" -- should NOT be transformed
+z.object({ description: z.string() });
+
+// z.object with both: shape field AND second-arg description
+z.object({ description: z.string(), name: z.string() }).describe(
+  "Schema with description field",
+);
+
+// Description with errorMap that only returns defaults (gets removed)
+z.string().describe("With error map");

--- a/test/test.ts
+++ b/test/test.ts
@@ -158,6 +158,12 @@ describe("Zod v3 to v4", () => {
       await runScenario("z-coerce");
     });
   });
+
+  describe("description param", () => {
+    it("converts `description` constructor param to `.describe()` method call", async () => {
+      await runScenario("description-param");
+    });
+  });
 });
 
 describe("Vue SFC files", () => {


### PR DESCRIPTION
 ## Summary
  - Converts `z.string({ description: "..." })` to `z.string().describe("...")`, which is the Zod v4 API

  ## Test plan
  - Added scenario test covering all supported cases
