### PR TITLE
feat: transform enum `.Values` to `.enum`

### DIFF
--- a/src/migrate.ts
+++ b/src/migrate.ts
@@ -118,6 +118,7 @@ export function migrateZodV3ToV4(
   convertSetErrorMapToConfig(sourceFile, zodName);
   convertZodErrorMapType(sourceFile, zodName);
   renameZSchemaEnumToLowercase(sourceFile, zodName);
+  renameZSchemaValuesWithEnum(sourceFile, zodName);
 
   convertAstroDeprecatedZodImports(importDeclarations);
 
@@ -181,6 +182,26 @@ function renameZSchemaEnumToLowercase(sourceFile: SourceFile, zodName: string) {
   sourceFile
     .getDescendantsOfKind(SyntaxKind.PropertyAccessExpression)
     .filter((node) => node.getName() === "Enum")
+    .filter((node) => {
+      const rootNode = findRootExpression(node);
+      const expression = rootNode?.getExpression();
+
+      const isFromZodEnum =
+        expression?.isKind(SyntaxKind.PropertyAccessExpression) &&
+        expression.getName() === "enum" &&
+        expression.getExpression().getText() === zodName;
+
+      return isFromZodEnum;
+    })
+    .forEach((node) => {
+      node.getNameNode().replaceWithText("enum");
+    });
+}
+
+function renameZSchemaValuesWithEnum(sourceFile: SourceFile, zodName: string) {
+  sourceFile
+    .getDescendantsOfKind(SyntaxKind.PropertyAccessExpression)
+    .filter((node) => node.getName() === "Values")
     .filter((node) => {
       const rootNode = findRootExpression(node);
       const expression = rootNode?.getExpression();

--- a/test/__scenarios__/z-enum.input.ts
+++ b/test/__scenarios__/z-enum.input.ts
@@ -8,9 +8,10 @@ enum Color {
 
 const ColorSchema = z.nativeEnum(Color);
 
-// Rename Enum to enum
+// Rename Enum and Values to enum
 const schema = z.enum(["id_token", "token", "code"]);
 schema.Enum.token;
+schema.Values.token;
 
 let mySchema: any;
 console.log("should not change:", mySchema.Enum.token);

--- a/test/__scenarios__/z-enum.output.ts
+++ b/test/__scenarios__/z-enum.output.ts
@@ -8,8 +8,9 @@ enum Color {
 
 const ColorSchema = z.enum(Color);
 
-// Rename Enum to enum
+// Rename Enum and Values to enum
 const schema = z.enum(["id_token", "token", "code"]);
+schema.enum.token;
 schema.enum.token;
 
 let mySchema: any;


### PR DESCRIPTION
This PR adds the capability to transform enum `.Values` to `.enum`.

`.Enum` is already transformed to `.enum`.

Docs: https://zod.dev/v4/changelog?id=znativeenum-deprecated

Fixes #141.