### PR TITLE
fix: transform non-string literal values of `required_error`

### DIFF
--- a/src/convert-zod-errors.ts
+++ b/src/convert-zod-errors.ts
@@ -244,17 +244,19 @@ export function convertDeprecatedErrorKeysToErrorFunction(node: ZodNode) {
     )
     .forEach((objectLiteral) => {
       const requiredErrorProp = objectLiteral.getProperty("required_error");
-      const requiredErrorValue = (
-        requiredErrorProp?.getLastChildIfKind(SyntaxKind.StringLiteral) ||
-        requiredErrorProp?.getLastChildIfKind(SyntaxKind.Identifier)
-      )?.getText();
+      const requiredErrorValue = requiredErrorProp?.isKind(
+        SyntaxKind.PropertyAssignment,
+      )
+        ? requiredErrorProp.getInitializer()?.getText()
+        : undefined;
 
       const invalidTypeErrorProp =
         objectLiteral.getProperty("invalid_type_error");
-      const invalidTypeErrorValue = (
-        invalidTypeErrorProp?.getLastChildIfKind(SyntaxKind.StringLiteral) ||
-        invalidTypeErrorProp?.getLastChildIfKind(SyntaxKind.Identifier)
-      )?.getText();
+      const invalidTypeErrorValue = invalidTypeErrorProp?.isKind(
+        SyntaxKind.PropertyAssignment,
+      )
+        ? invalidTypeErrorProp.getInitializer()?.getText()
+        : undefined;
 
       if (!requiredErrorProp && !invalidTypeErrorProp) {
         return;

--- a/test/__scenarios__/error-customization.drop-outdated-error-keys.input.ts
+++ b/test/__scenarios__/error-customization.drop-outdated-error-keys.input.ts
@@ -19,6 +19,9 @@ z.string({
   message: "This message takes precedence",
 });
 
+const required = (name: string) =>
+  z.string({ required_error: `The ${name} field is required` });
+
 const password = (requiredMessage: string) =>
   z.string({ required_error: requiredMessage }).min(12);
 

--- a/test/__scenarios__/error-customization.drop-outdated-error-keys.output.ts
+++ b/test/__scenarios__/error-customization.drop-outdated-error-keys.output.ts
@@ -18,6 +18,11 @@ z.string({
   error: "This message takes precedence",
 });
 
+const required = (name: string) =>
+  z.string({
+    error: (issue) => (issue.input === undefined ? `The ${name} field is required` : undefined),
+  });
+
 const password = (requiredMessage: string) =>
   z
     .string({


### PR DESCRIPTION
This PR generalises the logic which transforms `required_error` to mirror any value given (including template literals) into the generated ternary operator, rather than only string literals and identifiers.

Fixes #143.