### PR TITLE
fix: preserve normalization order when hoisting string formats

### DIFF
--- a/src/convert-name-to-top-level-api.ts
+++ b/src/convert-name-to-top-level-api.ts
@@ -392,6 +392,17 @@ function convertNameToTopLevelApi(
     }
 
     const newName = match.newName ?? match.name;
+
+    const pipedChain = buildPipedChain(callExpression, {
+      zodName,
+      formatName: match.name,
+      newName,
+    });
+    if (pipedChain) {
+      callExpression.replaceWithText(pipedChain);
+      return;
+    }
+
     let argsText = "";
 
     // Remove deprecated names from the chain
@@ -436,6 +447,89 @@ type ConvertNameOptions = {
   renames: { name: string; newName?: string }[];
   omitArgs?: boolean;
 };
+
+// Zod applies string checks in chain order, so `.trim()` before a format
+// normalizes the value first. Hoisting the format to the top-level API would
+// validate before normalizing, which silently rejects inputs that used to pass.
+function buildPipedChain(
+  callExpression: CallExpression,
+  {
+    zodName,
+    formatName,
+    newName,
+  }: { zodName: string; formatName: string; newName: string },
+) {
+  const chain = getChainPropertyAccessExpressions(callExpression).reverse();
+  const formatIndex = chain.findIndex((e) => e.getName() === formatName);
+
+  const format = chain[formatIndex];
+  const formatCall = format?.getParent();
+  if (!format || !formatCall?.isKind(SyntaxKind.CallExpression)) {
+    return undefined;
+  }
+
+  const beforeFormat = format.getExpression();
+  if (!normalizesBeforeValidating(beforeFormat)) {
+    return undefined;
+  }
+
+  const trailing = chain.slice(formatIndex + 1).map(toCallText);
+  const calls = trailing.filter((call) => call !== undefined);
+  // A chained property that isn't a call, we can't rebuild the chain safely
+  if (calls.length !== trailing.length) {
+    return undefined;
+  }
+
+  // Only string schemas have these, they wouldn't exist on the pipe
+  const isStringCheck = (call: { name: string }) =>
+    STRING_CHECK_METHODS.includes(call.name);
+  const checks = textOf(calls.filter(isStringCheck));
+  const wrappers = textOf(calls.filter((call) => !isStringCheck(call)));
+
+  const topLevelFormat = `${zodName}.${newName}(${getArgsText(formatCall)})`;
+  return `${beforeFormat.getText()}.pipe(${topLevelFormat}${checks})${wrappers}`;
+}
+
+function normalizesBeforeValidating(beforeFormat: Node) {
+  return getChainPropertyAccessExpressions(beforeFormat).some((e) =>
+    NORMALIZING_METHODS.includes(e.getName()),
+  );
+}
+
+const NORMALIZING_METHODS = ["trim", "toLowerCase", "toUpperCase"];
+
+const STRING_CHECK_METHODS = [
+  ...NORMALIZING_METHODS,
+  "min",
+  "max",
+  "length",
+  "nonempty",
+  "regex",
+  "includes",
+  "startsWith",
+  "endsWith",
+];
+
+function toCallText(expression: PropertyAccessExpression) {
+  const call = expression.getParent();
+  if (!call?.isKind(SyntaxKind.CallExpression)) {
+    return undefined;
+  }
+
+  const name = expression.getName();
+  return { name, text: `.${name}(${getArgsText(call)})` };
+}
+
+function textOf(calls: { text: string }[]) {
+  return calls.map((call) => call.text).join("");
+}
+
+function getArgsText(call: CallExpression) {
+  return call
+    .getArguments()
+    .map((arg) => arg.getText())
+    .join(", ");
+}
 
 function convertNameToTopLevelApiAndWrapInUnion(
   node: NodeToConvert,
@@ -498,6 +592,17 @@ function convertNameToTopLevelApiAndWrapInUnion(
           }
 
           // Default behavior: create union
+          // Piping keeps the normalization out of the union members
+          if (normalizesBeforeValidating(expression.getExpression())) {
+            const members = renames
+              .map(({ name }) => `${zodName}.${name}()`)
+              .join(", ");
+            parent.replaceWithText(
+              `${text}.pipe(${zodName}.union([${members}]))`,
+            );
+            return;
+          }
+
           const unionText = renames
             .map(({ name }) => `${text}.${name}()`)
             .join(", ");

--- a/test/__scenarios__/z-string.convert-cidr.output.ts
+++ b/test/__scenarios__/z-string.convert-cidr.output.ts
@@ -9,18 +9,22 @@ z.cidrv6().safeParse("2001:db8::/32");
 z.union([z.cidrv4(), z.cidrv6()]).safeParse("127.0.0.1/32");
 
 const cidrv4SchemaWithAttrs = z
-  .cidrv4()
+  .string()
   .trim()
+  .pipe(z.cidrv4())
   .optional()
   .describe("IPv4 CIDR Schema");
 
 const cidrv6SchemaWithAttrs = z
-  .cidrv6()
+  .string()
   .trim()
+  .pipe(z.cidrv6())
   .optional()
   .describe("IPv6 CIDR Schema");
 
 const cidrSchemaWithAttrs = z
-  .union([z.cidrv4().trim(), z.cidrv6().trim()])
+  .string()
+  .trim()
+  .pipe(z.union([z.cidrv4(), z.cidrv6()]))
   .optional()
   .describe("Some CIDR Schema");

--- a/test/__scenarios__/z-string.convert-ip.output.ts
+++ b/test/__scenarios__/z-string.convert-ip.output.ts
@@ -8,11 +8,23 @@ z.ipv4().safeParse("127.0.0.1");
 z.ipv6().safeParse("::1");
 z.union([z.ipv4(), z.ipv6()]).safeParse("127.0.0.1");
 
-const ipv4SchemaWithAttrs = z.ipv4().trim().optional().describe("IPv4 Schema");
+const ipv4SchemaWithAttrs = z
+  .string()
+  .trim()
+  .pipe(z.ipv4())
+  .optional()
+  .describe("IPv4 Schema");
 
-const ipv6SchemaWithAttrs = z.ipv6().trim().optional().describe("IPv6 Schema");
+const ipv6SchemaWithAttrs = z
+  .string()
+  .trim()
+  .pipe(z.ipv6())
+  .optional()
+  .describe("IPv6 Schema");
 
 const ipSchemaWithAttrs = z
-  .union([z.ipv4().trim(), z.ipv6().trim()])
+  .string()
+  .trim()
+  .pipe(z.union([z.ipv4(), z.ipv6()]))
   .optional()
   .describe("Some IP Schema");

--- a/test/__scenarios__/z-string.normalization-order.input.ts
+++ b/test/__scenarios__/z-string.normalization-order.input.ts
@@ -1,0 +1,34 @@
+import { z } from "zod";
+
+// Normalization runs before validation, the migration must preserve that
+z.string().trim().email();
+z.string().toLowerCase().uuid();
+z.string().trim().datetime();
+z.string().trim().ip();
+
+// Args still move to the top-level API
+z.string().trim().url("Please enter a valid URL");
+
+// Checks placed before the normalization stay on `z.string()`
+z.string().min(1).trim().email();
+
+// String checks placed after the format follow it
+z.string().trim().email().max(100);
+
+// Wrappers apply to the whole schema
+z.string().trim().email().optional();
+z.string().trim().email().describe("Contact email").max(100);
+
+// Normalization after the format is already in the right order
+z.string().email().trim();
+
+// Sanity check: non-Zod chain, left untouched
+class TextField {
+  trim() {
+    return this;
+  }
+  email() {
+    return this;
+  }
+}
+new TextField().trim().email();

--- a/test/__scenarios__/z-string.normalization-order.output.ts
+++ b/test/__scenarios__/z-string.normalization-order.output.ts
@@ -1,0 +1,34 @@
+import { z } from "zod/v4";
+
+// Normalization runs before validation, the migration must preserve that
+z.string().trim().pipe(z.email());
+z.string().toLowerCase().pipe(z.uuid());
+z.string().trim().pipe(z.iso.datetime());
+z.string().trim().pipe(z.union([z.ipv4(), z.ipv6()]));
+
+// Args still move to the top-level API
+z.string().trim().pipe(z.url("Please enter a valid URL"));
+
+// Checks placed before the normalization stay on `z.string()`
+z.string().min(1).trim().pipe(z.email());
+
+// String checks placed after the format follow it
+z.string().trim().pipe(z.email().max(100));
+
+// Wrappers apply to the whole schema
+z.string().trim().pipe(z.email()).optional();
+z.string().trim().pipe(z.email().max(100)).describe("Contact email");
+
+// Normalization after the format is already in the right order
+z.email().trim();
+
+// Sanity check: non-Zod chain, left untouched
+class TextField {
+  trim() {
+    return this;
+  }
+  email() {
+    return this;
+  }
+}
+new TextField().trim().email();

--- a/test/test.ts
+++ b/test/test.ts
@@ -82,6 +82,10 @@ describe("Zod v3 to v4", () => {
     it("replaces dropped `z.string().cidr()` with `z.union([z.cidrv4(), z.cidrv6()])`", async () => {
       await runScenario("z-string.convert-cidr");
     });
+
+    it("keeps normalization before validation when converting to top-level APIs", async () => {
+      await runScenario("z-string.normalization-order");
+    });
   });
 
   // https://zod.dev/v4/changelog?id=default-updates


### PR DESCRIPTION
Hoisting the format to the top-level API was moving it in front of the normalization, so the value got validated before it was normalized:

```ts
// before
z.string().trim().email()

// after (wrong: validates the untrimmed input)
z.email().trim()
```

Now we pipe instead, which keeps the original order:

```ts
z.string().trim().pipe(z.email())
```

Only kicks in when `.trim()`, `.toLowerCase()` or `.toUpperCase()` comes before the format. Anything chained after it goes inside the pipe if it's a string check (`.min()`, `.regex()`…), outside otherwise (`.optional()`, `.describe()`…).

Also fixed the `z.string().ip()` and `z.string().cidr()` scenarios that had the same bug in their expected output.

Fixes #174