### PR TITLE
fix: publish releases on Node 24 LTS

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -8,7 +8,7 @@ runs:
     - uses: actions/setup-node@v4
       with:
         cache: pnpm
-        node-version: "23"
+        node-version: "24"
     - run: pnpm install --frozen-lockfile
       shell: bash
   using: composite

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -41,12 +41,8 @@ jobs:
         if: ${{ steps.release.outputs.release_created }}
         with:
           cache: pnpm
-          node-version: "23"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
-      # Ensure npm 11.5.1 or later for trusted publishing
-      - name: Update npm
-        if: ${{ steps.release.outputs.release_created }}
-        run: npm install -g npm@latest
       - name: Build
         if: ${{ steps.release.outputs.release_created }}
         run: |

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-nodejs v23.6.0
+nodejs 24.16.0
 pnpm 9.15.4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ Codemod CLI that migrates Zod v3 code to v4. Uses **ts-morph** for AST-based tra
 - **ESM module** (`"type": "module"`)
 - **ts-morph** for AST manipulation (not jscodeshift)
 - **Vitest** for testing
-- **pnpm 9.15.4**, Node.js 23.6.0 (see `.tool-versions`)
+- **pnpm 9.15.4**, Node.js 24.16.0 (see `.tool-versions`)
 - **TypeScript strict mode** with `noUncheckedIndexedAccess`
 - Import paths use `.ts` extensions (`rewriteRelativeImportExtensions`)
 


### PR DESCRIPTION
The v1.21.4 release never made it to npm — [the publish job failed](https://github.com/nicoespeon/zod-v3-to-v4/actions/runs/33200697641/job/98949136998) before it could run. The GitHub release and tag exist, but npm is still on 1.21.3.

## Why it broke

The workflows pinned Node 23, which is EOL and bundles npm 10.9.2. Trusted publishing needs npm 11.5.1+, so the release job worked around it with `npm install -g npm@latest`. That worked until npm 12 shipped and dropped Node 23 from its supported engines, at which point the step started exiting 1.

## The fix

Node 24 LTS bundles npm 11.19, so the workaround step goes away entirely rather than being pinned to a version that would eventually rot the same way.

- Workflows and `.tool-versions` move to Node 24
- The `Update npm` step is deleted

Verified locally on Node 24.16.0: typecheck, all 55 tests, build, and `npm publish --dry-run` all pass, with npm 11.13.0 already above the trusted-publishing floor.

## Note on versions

1.21.4 stays a GitHub-only release. Merging this cuts 1.21.5, which publishes with the repaired workflow and carries 1.21.4's changes with it.